### PR TITLE
Add stripUnderscores in fluentOperator helm chart

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
@@ -14,6 +14,7 @@ spec:
     path: {{ .Values.fluentbit.input.systemd.path }}
     db: /fluent-bit/tail/systemd.db
     dbSync: Normal
+    stripUnderscores: {{ .Values.fluentbit.input.systemd.stripUnderscores }}
     systemdFilter:
       - _SYSTEMD_UNIT={{ .Values.containerRuntime }}.service
       {{- if .Values.fluentbit.input.systemd.includeKubelet }}

--- a/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
@@ -14,7 +14,7 @@ spec:
     path: {{ .Values.fluentbit.input.systemd.path }}
     db: /fluent-bit/tail/systemd.db
     dbSync: Normal
-    stripUnderscores: {{ .Values.fluentbit.input.systemd.stripUnderscores }}
+    stripUnderscores: {{ .Values.fluentbit.input.systemd.stripUnderscores | quote }}
     systemdFilter:
       - _SYSTEMD_UNIT={{ .Values.containerRuntime }}.service
       {{- if .Values.fluentbit.input.systemd.includeKubelet }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -122,6 +122,7 @@ fluentbit:
       enable: true
       path: "/var/log/journal"
       includeKubelet: true
+      stripUnderscores: "off"
     nodeExporterMetrics: {}
     # uncomment below nodeExporterMetrics section if you want to collect node exporter metrics
   #   nodeExporterMetrics:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Adding stripUnderscores flag in Fluent Operator Helm chart.  Updated Systemd Input template to use this flag from the Chart Values.yaml

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```