### PR TITLE
Add options in FluentOperator helm chart to add more systemdFilter in Fluentbit Systemd Input

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
@@ -16,10 +16,15 @@ spec:
     dbSync: Normal
     stripUnderscores: {{ .Values.fluentbit.input.systemd.stripUnderscores | quote }}
     systemdFilter:
+{{- if .Values.fluentbit.input.systemd.systemdFilter.enable }}
       - _SYSTEMD_UNIT={{ .Values.containerRuntime }}.service
       {{- if .Values.fluentbit.input.systemd.includeKubelet }}
       - _SYSTEMD_UNIT=kubelet.service
       {{- end }}
+      {{- if .Values.fluentbit.input.systemd.systemdFilter.filters }}
+{{- toYaml .Values.fluentbit.input.systemd.systemdFilter.filters | nindent 6 }}
+      {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -124,6 +124,9 @@ fluentbit:
       readFromHead: false
     systemd:
       enable: true
+      systemdFilter:
+        enable: true
+        filters: []
       path: "/var/log/journal"
       includeKubelet: true
       stripUnderscores: "off"


### PR DESCRIPTION
Add options in FluentOperator helm chart to add more systemdFilter in Fluentbit Systemd Input and a condition on systemdFilter to enable/disable

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```