### PR TITLE
Add podSecurityContext for fluentbit in fluent operator helm chart

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -60,5 +60,9 @@ spec:
   labels:
 {{ toYaml .Values.fluentbit.labels | indent 4 }}
   {{- end }}
+  {{- if .Values.fluentbit.podSecurityContext }}
+  securityContext:
+{{ toYaml .Values.fluentbit.podSecurityContext | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -79,6 +79,8 @@ fluentbit:
   imagePullSecrets: []
   # - name: "image-pull-secret"
   secrets: []
+  # Pod security context for Fluent Bit pods. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext: {}
   # List of volumes that can be mounted by containers belonging to the pod.
   additionalVolumes: []
   # Pod volumes to mount into the container's filesystem.


### PR DESCRIPTION
Add podSecurityContext for fluentbit in fluent operator helm chart

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```