### PR TITLE
Fix duplicate cluster parser in fluent-operator

### DIFF
--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
@@ -280,8 +280,8 @@ func (cfg ClusterFluentBitConfig) RenderMainConfig(sl plugins.SecretLoader, inpu
 func (cfg ClusterFluentBitConfig) RenderParserConfig(sl plugins.SecretLoader, parsers ClusterParserList, nsParserLists []ParserList,
 	nsClusterParserLists []ClusterParserList) (string, error) {
 	var buf bytes.Buffer
-
-	parserSections, err := parsers.Load(sl)
+	existingParsers := make(map[string]bool)
+	parserSections, err := parsers.Load(sl, existingParsers)
 	if err != nil {
 		return "", err
 	}
@@ -304,7 +304,7 @@ func (cfg ClusterFluentBitConfig) RenderParserConfig(sl plugins.SecretLoader, pa
 	}
 
 	for _, item := range nsClusterParserLists {
-		nsClusterParserSections, err := item.Load(sl)
+		nsClusterParserSections, err := item.Load(sl, existingParsers)
 		if err != nil {
 			return "", err
 		}

--- a/apis/fluentbit/v1alpha2/clusterparser_types.go
+++ b/apis/fluentbit/v1alpha2/clusterparser_types.go
@@ -88,12 +88,14 @@ func (a ParserByName) Len() int           { return len(a) }
 func (a ParserByName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ParserByName) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
-func (list ClusterParserList) Load(sl plugins.SecretLoader) (string, error) {
+func (list ClusterParserList) Load(sl plugins.SecretLoader, existingParsers map[string]bool) (string, error) {
 	var buf bytes.Buffer
 
 	sort.Sort(ParserByName(list.Items))
-
 	for _, item := range list.Items {
+		if existingParsers[item.Name] {
+			continue
+		}
 		merge := func(p plugins.Plugin) error {
 			if p == nil || reflect.ValueOf(p).IsNil() {
 				return nil
@@ -117,6 +119,7 @@ func (list ClusterParserList) Load(sl plugins.SecretLoader) (string, error) {
 					buf.WriteString(fmt.Sprintf("    Decode_Field_As    %s\n", decorder.DecodeFieldAs))
 				}
 			}
+			existingParsers[item.Name] = true
 			return nil
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```